### PR TITLE
adjust Product and Service

### DIFF
--- a/v3/catalog-shacl.shce
+++ b/v3/catalog-shacl.shce
@@ -65,6 +65,10 @@ shape :ServiceShape -> ex:Service ;
 	ex:subType [1..1] in=[con:GeneralPurposePodService con:SpecializedPodService con:CommunicationService con:IdentityService con:StorageService] %
 		sh:name "subtype"@en
 	% .
+	ex:launchAt IRI [0..1] %
+		sh:name "launch at" ;
+		sh:description "URL that can be opened in a web browser to use this app/service"
+	% .
 	ex:status [1..1] in=[con:Exploration con:Development con:Production con:Archived] %
 		sh:name "status"@en
 	% .
@@ -95,13 +99,9 @@ shape :ServiceShape -> ex:Service ;
 		sh:name "social keyword"@en ;
 		sh:description "comma-separated list for specialized services e.g. housing, transportation, name of an industry"
 	% .
-	ex:serviceBackend IRI %
-		sh:name "service backend"@en ;
-		sh:description "name of server software (e.g. ESS for inrupt.com)"
-	% .
-	ex:serviceFrontend IRI %
-		sh:name "service frontend"@en ;
-		sh:description "name of server frontend (e.g. SolidOS or Penny)"
+	ex:softwareStackIncludes IRI %
+		sh:name "software stack includes"@en ;
+		sh:description "software used in this deplyoment"
 	% .
 	ex:serviceAudience xsd:string [0..1] %
 		sh:name "service audience"@en ;
@@ -143,9 +143,9 @@ shape :ProductShape -> ex:Product ;
 	ex:repository IRI [0..1] %
 		sh:name "repository"@en
 	% .
-	ex:webAppEndpoint IRI [0..1] %
-		sh:name "Webapp URL" ;
-		sh:description "URL of an app that can be run from an online endpoint"
+	ex:showcase IRI [0..1] %
+		sh:name "showcase" ;
+		sh:description "Service with a showcase/demo deployment"
 	% .
 	ex:provider IRI %
 		sh:name "provider"@en ;


### PR DESCRIPTION
Based on the discussion during the call.
I left the ClientID in, since I plan to make a separate PR removing it together with WebID based on converstaion in #16 

We didn't get into issues I see with current frontend/backend. In the data they are currently used times:

* serviceFrontend: 6
* serviceBackend: 19

My main problem is that they don't allow to clearly model various types of deployments #22 while instead possibly being confusing for people who want to describe their service. Looking at current 6 examples of `serviceFrontend` I think those which link to Penny or SoildOS work differently than those linking to SleepyBike or PASSplatform.

Application can have both frontends and backends. Also many core services come with some minimal frontend, for example CSS has it's own account management frontend. SAI Authorization Agent has both frontend and backed with custom RPC based API.

Given that we already have taxonomy to categorize different type of software (Product) this already gives enough information to customize display of different kinds of software in a deployed stack. Having a single generic property that can be used to link deployment to any kind of software being used seems sufficient. At least until we come up with more detailed way of modeling different kinds of deployments #22 