### PR TITLE
fix: add SKOS subtypes for ClassOfProduct

### DIFF
--- a/catalog-data.ttl
+++ b/catalog-data.ttl
@@ -4174,80 +4174,105 @@ cdata:Solid_E2EE a ex:CreativeWork ;
 
 
 cdata:SAI_Application a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "SAI Application" .
 
 cdata:SAI_Authorization_Agent a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "SAI Authorization Agent" .
 
 cdata:ACP_Resource_Server a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "ACP Resource Server" .
 
 cdata:ACP_Server a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "ACP Server" .
 
 <https://solidproject.org/TR/oidc#Client> a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid-OIDC Client" .
 
 <https://solidproject.org/TR/oidc#Provider> a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid-OIDC Provider" .
 
 <https://solidproject.org/TR/wac#Client> a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "WAC Client" .
 
 <https://solidproject.org/TR/wac#Server> a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "WAC Server" .
 
 <https://solidproject.org/TR/protocol#Client> a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Client" .
 
 <https://solidproject.org/TR/protocol#Server> a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Server" .
 
 <https://solidproject.org/TR/notifications-protocol#ResourceServer> a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Notifications Resource Server" .
 
 <https://solidproject.org/TR/notifications-protocol#DiscoveryClient> a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Notifications Discovery Client" .
 
 <https://solidproject.org/TR/notifications-protocol#SubscriptionClient> a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Notifications Subscription Client" .
 
 <https://solidproject.org/TR/notifications-protocol#SubscriptionServer> a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Notifications Subscription Server" .
 
 <https://solidproject.org/TR/notifications-protocol#NotificationSender> a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Notifications Notification Sender" .
 
 <https://solidproject.org/TR/notifications-protocol#NotificationReceiver> a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Notifications Notification Receiver" .
 
 cdata:WebPushChannel2023NotificationSender a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid WebPush Notification Sender" .
 
 cdata:WebPushChannel2023SubscriptionServer a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid WebPush Subscription Server" .
 
 cdata:WebhookChannel2023SubscriptionClient a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Webhook Subscription Client" .
 
 cdata:WebhookChannel2023SubscriptionServer a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Webhook Subscription Server" .
 
 cdata:WebhookChannel2023NotificationSender a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Webhook Notification Sender" .
 
 cdata:WebhookChannel2023NotificationReceiver a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Webhook Notification Receiver" .
 
 cdata:StreamingHTTPChannel2023NotificationSender a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Streaming HTTP Notification Sender" .
 
 cdata:StreamingHTTPChannel2023NotificationReceiver a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid Streaming HTTP Notification Receiver" .
 
 cdata:WebSocketChannel2023SubscriptionServer a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid WebSocket Subscription Server" .
 
 cdata:WebSocketChannel2023NotificationSender a ex:ClassOfProduct ;
+  ex:subType con:ClassOfProduct ;
   ex:name "Solid WebSocket Notification Sender" .
-


### PR DESCRIPTION
This allows the ClassOfProduct to be handled by the scripts but shouldn't impact solid-efforts use of it.