### PR TITLE
refactor: remove maxCount 1 from ex:about

### DIFF
--- a/catalog-shacl.shce
+++ b/catalog-shacl.shce
@@ -15,7 +15,7 @@ shape :CreativeWorkShape -> ex:CreativeWork ;
 	ex:subType [1..*] in=[con:AboutSolid con:AboutSolidApps con:ResearchPaper con:OtherLearningResource con:OtherTechResource] %
 		sh:name "subtype"@en
 	% .
-	ex:about IRI [0..1] %
+	ex:about IRI %
 		sh:name "references" ;
 		sh:description "if specific to a product, the  name of the product"
 	% .


### PR DESCRIPTION
Changed the number but did not change the name for ex:about shape in CreativeWorkShape.  We'll have to change the name anyway eventually, so I would prefer to do it all at once rather than having to change the data now.