### PR TITLE
fetch programming languages names from wikidata

### DIFF
--- a/catalog-data.ttl
+++ b/catalog-data.ttl
@@ -4,6 +4,8 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix wd: <http://www.wikidata.org/entity/> .
+@prefix wdt: <http://www.wikidata.org/prop/direct/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://harth.org/andreas/foaf#ah> a ex:Person ;
@@ -12,6 +14,57 @@
   ex:modified "2025-04-25T07:53:45.052Z"^^xsd:dateTime ;
   ex:name "Andreas Harth" ;
   ex:webid <http://harth.org/andreas/foaf#ah> .
+
+wd:Q161053 ex:name "Ruby" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q17147733 ex:name "Swift" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q2005 ex:name "JavaScript" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q2370 ex:name "C#" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q251 ex:name "Java" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q28865 ex:name "Python" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q34010 ex:name "Haskell" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q37227 ex:name "Go" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q3816639 ex:name "Kotlin" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q406009 ex:name "Dart" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q42478 ex:name "Perl" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q460584 ex:name "Scala" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q51885456 ex:name "Zig" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q5362035 ex:name "Elixir" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q575650 ex:name "Rust" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q59 ex:name "PHP" ;
+  wdt:P31 wd:Q9143 .
+
+wd:Q978185 ex:name "TypeScript" ;
+  wdt:P31 wd:Q9143 .
 
 <https://45h.inrupt.net/profile/card#me> a ex:Person ;
   ex:name "Luc" ;

--- a/cli/aggregations/wikidata.ts
+++ b/cli/aggregations/wikidata.ts
@@ -1,0 +1,47 @@
+import { DataFactory, Store } from 'n3'
+import { dereferenceToStore } from 'rdf-dereference-store'
+import { queryDataset, prefixes, ex, schema } from '../util.ts'
+import type { NamedNode } from '@rdfjs/types'
+
+export async function aggregateWikidata(dataset: Store): Promise<Store> {
+  return aggregateProgrammingLanguages(dataset)
+}
+
+async function getName(store: Store, language: NamedNode, tag: string): Promise<string | undefined> {
+  const query = `
+      SELECT ?s ?name
+      WHERE {
+        <${language.value}> <${schema.name}> ?name
+        FILTER ( LANG(?name) = "${tag}" )
+      }`
+
+  let bindings = await queryDataset(store, query)
+  return bindings[0]?.get('name')?.value
+}
+
+export async function aggregateProgrammingLanguages(dataset: Store): Promise<Store> {
+  const instanceOf = `${prefixes.wdt}P31`
+  const ProgrammingLanguage = `${prefixes.wd}Q9143`
+  const langQuery = `
+    SELECT ?s ?name
+    WHERE {
+      ?s <${instanceOf}> <${ProgrammingLanguage}> .
+      OPTIONAL { ?s <${ex.name}> ?name . }
+    }`
+  const lbindings = await queryDataset(dataset, langQuery)
+  const withoutNames = lbindings.filter(b => !b.get('name')).map(b => b.get('s') as NamedNode)
+  console.info(`Fetching names for programming langages: ${withoutNames.length}`)
+  for (const language of withoutNames) {
+    const { store } = await dereferenceToStore(language.value.replace('http', 'https'))
+    let name = await getName(store, language, 'en')
+    if (!name) name = await getName(store, language, 'mul')
+    if (!name) {
+      console.warn(`Couldn't find name for ${language.value}`)
+      continue
+    }
+    const quad = DataFactory.quad(language, ex.terms.name, DataFactory.literal(name))
+    dataset.add(quad)
+  }
+  return dataset
+}
+

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -6,6 +6,7 @@ import { validateWebid } from './validations/webid.ts'
 import { migrateWebid } from './migrations/webid.ts'
 import { aggregateW3C } from './aggregations/w3c.ts'
 import { aggregateGithub } from './aggregations/github.ts'
+import { aggregateWikidata } from './aggregations/wikidata.ts'
 
 const dataPath = getPath(import.meta.url, '../catalog-data.ttl')
 const dataset = await loadData(dataPath)
@@ -55,6 +56,14 @@ aggregate.command('github')
   .action(async () => {
     console.info('Fetching data from Github API')
     const updated = await aggregateGithub(dataset)
+    await saveData(updated, dataPath)
+  })
+
+aggregate.command('wikidata')
+  .description('Adds data from Wikidata')
+  .action(async () => {
+    console.info('Fetching data Wikiadta')
+    const updated = await aggregateWikidata(dataset)
     await saveData(updated, dataPath)
   })
 

--- a/cli/util.ts
+++ b/cli/util.ts
@@ -10,19 +10,14 @@ import { QueryEngine } from '@comunica/query-sparql-rdfjs'
 import { Store } from 'n3'
 import { write } from '@jeswr/pretty-turtle'
 
-const prefixes = {
+export const prefixes = {
   rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
   xsd: 'http://www.w3.org/2001/XMLSchema#',
+  wd: 'http://www.wikidata.org/entity/',
+  wdt: 'http://www.wikidata.org/prop/direct/',
   con: 'https://solidproject.solidcommunity.net/catalog/taxonomy#',
   cdata: 'https://solidproject.solidcommunity.net/catalog/data#',
   ex: 'http://example.org#',
-}
-
-export async function formatData(filePath: string): Promise<void> {
-  const fromStream = await readQuadStream(filePath)
-  const fromQuads = await arrayifyStream(fromStream)
-  const outString = await write(fromQuads, { prefixes, ordered: true })
-  fs.writeFileSync(filePath, outString)
 }
 
 export async function loadData(filePath: string): Promise<Store> {
@@ -35,7 +30,9 @@ export async function saveData(dataset: Store, filePath: string): Promise<void> 
   fs.writeFileSync(filePath, outString)
 }
 
-export const ex = createVocabulary('http://example.org#', 'webid', 'siloId', 'member', 'siloUsername', 'Person', 'Organization')
+export const ex = createVocabulary('http://example.org#', 'name', 'webid', 'siloId', 'member', 'siloUsername', 'Person', 'Organization')
+export const schema = createVocabulary('http://schema.org/', 'name')
+export const rdfs = createVocabulary('http://www.w3.org/2000/01/rdf-schema#', 'label')
 
 export function getPath(from: string, to: string): string {
   const __filename = fileURLToPath(from)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@comunica/query-sparql-rdfjs": "^4.3.0",
         "commander": "^14.0.0",
         "mashlib": "^1.10.4",
-        "node-w3capi": "^2.2.0"
+        "node-w3capi": "^2.2.0",
+        "rdf-dereference-store": "^1.4.0"
       },
       "bin": {
         "catalog": "cli/index.ts"
@@ -648,7 +649,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-4.2.0.tgz",
       "integrity": "sha512-MtDTZj1zUrzj8zte74+3KnMVaJrQfQm15AquK3g8XwJYwDEPJwT5bDRenb/TXlcG6qio9MamY4iYkgsCRPmPVQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-dereference": "^4.2.0",
@@ -663,7 +663,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-file/-/actor-dereference-file-4.2.0.tgz",
       "integrity": "sha512-Dq+y1gmZ/ExEqrEyTTBOg6h4nxNjivF35KjMexmnIS1tLD9+coaa0lOV3H5VyF40i+P/Bo9c0N940yYKoN30CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-dereference": "^4.2.0",
@@ -678,7 +677,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-4.2.0.tgz",
       "integrity": "sha512-FKyO0N15QKanXc5mHAdLTaI0BXEhs2A6uxGr0IwcAePaMFt+fjxlG/sz97PeSgVzoW60nLD21a29KVN6cTGbMg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-dereference": "^4.2.0",
@@ -696,7 +694,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-4.2.0.tgz",
       "integrity": "sha512-i8Buj5Vlf6C7cA59Y8DqPjVABSDQZtjOgME/dheGrLdGm04xES+MRBwjLIhYnXadBns0Kk/UjIsnSI+k6sEXdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-dereference": "^4.2.0",
@@ -1686,7 +1683,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-4.2.0.tgz",
       "integrity": "sha512-oZMNb01Jpc+e/0/b8+zRjQsNrEndfIiA6UpN0os4hROHw3QBw3ewT05g/GZUp7V+Fo/uSA4akUUqDsLKyZxRaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-http": "^4.2.0",
@@ -3890,7 +3886,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-4.2.0.tgz",
       "integrity": "sha512-g3WBPzZ76AnMqNc9EJ0NYrF/3YYyyv5xz07yLtoRPwseT/ADdXszMLnkqlrNvh0hoz2DV4RVBynW7X/3gcv83A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-rdf-parse": "^4.2.0",
@@ -3910,7 +3905,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-4.2.0.tgz",
       "integrity": "sha512-BcwVDfgtGKbXcdi7FHNzGiwOwZim629obfiHJsCFz/u+/ijQ9uQCbkBYILkvlNDBhJGhV2g+z0WdyJnnrVH6nA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-rdf-parse-html": "^4.2.0",
@@ -3928,7 +3922,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-4.2.0.tgz",
       "integrity": "sha512-frs09nzpFCpGV8w3MRT9SvHiBeeiMWnvVh/aJ1XKgzZh4sXYvUyf1nPMf5eUCa8tv3x4k1Rt+1ryd5nHyPRLOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-rdf-parse-html": "^4.2.0",
@@ -3946,7 +3939,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-4.2.0.tgz",
       "integrity": "sha512-zbH9NSDPmufxJvbHdsQK3QwDf5Et/ywXElgCG+sPHdtJTqjKG/cuQSF3xwM1xYl++kLXR0KY3bz/EIQGRsq/OA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-rdf-parse": "^4.2.0",
@@ -3967,7 +3959,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -3984,7 +3975,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4005,7 +3995,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -4015,7 +4004,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -4032,7 +4020,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4053,7 +4040,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -4063,7 +4049,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-4.2.0.tgz",
       "integrity": "sha512-qD+tuwx/E5z+c55hWrjtRWmS+tMw/ZPJgvNmD+DEUYf1LCeJ3WqjMEa3u783eVxNCXTJQ/CguVm5kZGKwG669w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-http": "^4.2.0",
@@ -4084,7 +4069,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-4.3.0.tgz",
       "integrity": "sha512-kDVTeefCi1PpTuDDm+lLumz2nUofPxvPeeOO531FKtky5tAfT9SZGblptAgM1EgdKqruH00IJ6+KLXFb1XbjDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-rdf-parse": "^4.2.0",
@@ -4097,7 +4081,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-4.2.0.tgz",
       "integrity": "sha512-0bhARRt80pEgVRDPb8xmtgKOrXS6ccV/XJMfmXTFEN2y5BCdXPKVazN/QEH7GBIrx/GkgQGXFwnprIvJlRJbag==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-rdf-parse": "^4.2.0",
@@ -4113,7 +4096,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-4.2.0.tgz",
       "integrity": "sha512-qnTAFZEYofrwuhjGi1ToMs33BuUjvdklixQ9odEUcGTbUhrhCkcI2VqE7etDVkn3RlmEAHLseWHkCWEWWS167Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-rdf-parse": "^4.2.0",
@@ -4133,7 +4115,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -4150,7 +4131,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4171,7 +4151,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -4181,7 +4160,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-4.2.0.tgz",
       "integrity": "sha512-PMRVpUSGzUieRpW7ffkciaX+x+QkgtlD/2lu2Ru7EPo/NwM5yelshwdv7VDv/lYeWOKwrx01GQgTQSU8dPDeoQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/bus-rdf-parse": "^4.2.0",
@@ -4817,7 +4795,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-4.2.0.tgz",
       "integrity": "sha512-pQPHa2IMPPuicQQYQ2IlgFuUa7JBPRohSe3uMhUfcAUv9aGZKcIrlFdXCQPnUc+HLNU/f/06HmcWiXtgS8YujQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/core": "^4.2.0",
@@ -10191,7 +10168,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11750,7 +11726,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
       "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
-      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -12508,7 +12483,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-4.0.1.tgz",
       "integrity": "sha512-6M4y9YGgADk3nXJebbRrxEdMVBJ9bnz+peAvjTXUievopqaE8sg/qml/I6Sp1ln7rpOKffsNZWSre6B7N76szw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bergos/jsonparse": "^1.4.0",
@@ -12531,7 +12505,6 @@
       "version": "18.19.112",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
       "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -12541,7 +12514,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-3.0.0.tgz",
       "integrity": "sha512-Kg6TVtBUdIm057ht/8WNhM9BROt+BeYaDGXbzrKaa3xA99csee+CsD8IMCTizRgzoO8PIzvzcxxCoRvpq1xNQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-link-header": "^1.0.1",
@@ -12557,7 +12529,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -12574,7 +12545,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12595,7 +12565,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -12605,7 +12574,6 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonld-streaming-serializer": {
@@ -17646,7 +17614,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/rdf-dereference/-/rdf-dereference-4.0.0.tgz",
       "integrity": "sha512-hv7uqIHTB9M/OnS69hrSwNVBo/4+CFLwdVCL6Lg7z0+KLDJChZmTK5e6CFQ8v0OL1TJTSETGx2/EORhOwuZfFQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/actor-dereference-fallback": "^4.0.1",
@@ -17688,6 +17655,76 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-dereference-store": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rdf-dereference-store/-/rdf-dereference-store-1.4.0.tgz",
+      "integrity": "sha512-VWobImdfxG46vBGzD8V/CJ6+zSC5FPt16Fe0PUyK+jUQG5hYbGDp0+U7fcaeK5Xif8y9kA0mXPUy2k/Qn9PWLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.1.0",
+        "@types/n3": "^1.16.4",
+        "asynciterator": "^3.9.0",
+        "event-emitter-promisify": "^1.1.0",
+        "n3": "^1.17.3",
+        "rdf-dereference": "^4.0.0",
+        "rdf-parse": "^4.0.0",
+        "readable-stream": "^4.5.2"
+      }
+    },
+    "node_modules/rdf-dereference-store/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rdf-dereference-store/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/rdf-dereference-store/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/rdf-dereference-store/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/rdf-ext": {
@@ -17936,7 +17973,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-4.0.0.tgz",
       "integrity": "sha512-lNVuUKPVAdX9lJYYrJFhdQHFulYjk95BYvuNsE+eUs/M93sdsovH/Ga8bTAxagmpsoQ4LzMPa2YqeHX8ysltOA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@comunica/actor-http-fetch": "^4.0.1",
@@ -17975,7 +18011,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -17992,7 +18027,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18013,7 +18047,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "@comunica/query-sparql-rdfjs": "^4.3.0",
     "commander": "^14.0.0",
     "mashlib": "^1.10.4",
-    "node-w3capi": "^2.2.0"
+    "node-w3capi": "^2.2.0",
+    "rdf-dereference-store": "^1.4.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",


### PR DESCRIPTION
This PR only adds a handful of programming languages from wikidata. It also provides a script to fetch their names/labels, it tries `@en` and falls back to `@mul` saving it without a language tag.

@jeff-zucker whenever you are ready to upate your viewer we can manually update those few current entries. I don't think it matters for your forms since you are processing them by hand anyways.

After that we can update the `SoftwareShape`

```bash
cat catalog-data.ttl | grep programmingLanguage
  ex:programmingLanguage "typescript" ;
  ex:programmingLanguage "javascript" ;
  ex:programmingLanguage "javascript" ;
  ex:programmingLanguage "Javascript" ;
  ex:programmingLanguage "Swift" ;
  ex:programmingLanguage "Typescript" ;
  ex:programmingLanguage "Typescript" ;
  ex:programmingLanguage "Python" ;
  ex:programmingLanguage "PHP" ;
  ex:programmingLanguage "javascript" ;
  ex:programmingLanguage "Typescript" ;
  ex:programmingLanguage "Python" ;
  ex:programmingLanguage "javascript" ;
  ex:programmingLanguage "Perl" ;
```